### PR TITLE
Add a reasonable email validation and test

### DIFF
--- a/lib/challah/validators/email_validator.rb
+++ b/lib/challah/validators/email_validator.rb
@@ -15,7 +15,7 @@ module Challah
 
     # A reasonable-email-looking regexp pattern
     def self.pattern
-      /\A[A-Z0-9._%a-z\-]+@[A-Z0-9a-z\-]+\.+[A-Za-z]{2,}\z/
+      /\A[A-Z0-9._%a-z\-]+@((?:[-\p{L}\d]+\.)+\p{L}{2,})\s*\z/
     end
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -132,6 +132,30 @@ module Challah
       user.email = 'john@challah.me'
       assert_equal true, user.valid?
 
+      user.email = 'john@challah.co.me'
+      assert_equal true, user.valid?
+
+      user.email = 'john.smith@challah.me'
+      assert_equal true, user.valid?
+
+      user.email = 'john-smith@challah.me'
+      assert_equal true, user.valid?
+
+      user.email = 'john_smith@challah.me'
+      assert_equal true, user.valid?
+
+      user.email = 'john@chal@lah.me'
+      assert_equal false, user.valid?
+
+      user.email = 'john,smith@challah.me'
+      assert_equal false, user.valid?
+
+      user.email = 'john_ smith@challah.me'
+      assert_equal false, user.valid?
+
+      user.email = 'john+smith@challah.me'
+      assert_equal false, user.valid?
+
       user.email = 'john@challah.m@me.e'
       assert_equal false, user.valid?
     end


### PR DESCRIPTION
This pr adds a different regex that accepts email with similar gmail
standard policy, except that the pr is accepting email with underscore
like_this@example.com, so less strict
